### PR TITLE
Add go mod support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,15 @@
+module github.com/elliotchance/redis-usage
+
+go 1.14
+
+require (
+	github.com/go-redis/redis v6.12.0+incompatible
+	github.com/labstack/gommon v0.2.2-0.20180613044413-d6898124de91
+	github.com/mattn/go-colorable v0.0.9
+	github.com/mattn/go-isatty v0.0.3
+	github.com/mattn/go-runewidth v0.0.2
+	github.com/valyala/bytebufferpool v1.0.0
+	github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4
+	golang.org/x/sys v0.0.0-20180622082034-63fc586f45fe
+	gopkg.in/cheggaaa/pb.v1 v1.0.25
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/go-redis/redis v6.12.0+incompatible h1:s+64XI+z/RXqGHz2fQSgRJOEwqqSXeX3dliF7iVkMbE=
+github.com/go-redis/redis v6.12.0+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
+github.com/labstack/gommon v0.2.2-0.20180613044413-d6898124de91/go.mod h1:/tj9csK2iPSBvn+3NLM9e52usepMtrd5ilFYA+wQNJ4=
+github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-runewidth v0.0.2 h1:UnlwIPBGaTZfPQ6T1IGzPI0EkYAQmT9fAEJ/poFC63o=
+github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4/go.mod h1:50wTf68f99/Zt14pr046Tgt3Lp2vLyFZKzbFXTOabXw=
+golang.org/x/sys v0.0.0-20180622082034-63fc586f45fe h1:ay7inWg28/GEO1erz2KR0ywSgsw4yPHUw1egz2vGcN0=
+golang.org/x/sys v0.0.0-20180622082034-63fc586f45fe/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+gopkg.in/cheggaaa/pb.v1 v1.0.25 h1:Ev7yu1/f6+d+b3pi5vPdRPc6nNtP1umSfcWiEfRqv6I=
+gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=


### PR DESCRIPTION
Add go mod support to make sure go get would not break.
Current setup require user to use Gopkg to build, not a simple go get.

go get will show:
```
# github.com/elliotchance/redis-usage
../../go/src/github.com/elliotchance/redis-usage/main.go:119:34: not enough arguments in call to client.cmdable.Scan
	have (uint64, string, int64)
	want (context.Context, uint64, string, int64)
../../go/src/github.com/elliotchance/redis-usage/main.go:133:31: not enough arguments in call to client.cmdable.Dump
	have (string)
	want (context.Context, string)
../../go/src/github.com/elliotchance/redis-usage/main.go:208:23: client.DbSize undefined (type *redis.Client has no field or method DbSize)
../../go/src/github.com/elliotchance/redis-usage/main.go:215:23: not enough arguments in call to client.cmdable.Ping
	have ()
	want (context.Context)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/redis-usage/2)
<!-- Reviewable:end -->
